### PR TITLE
Update nodejs download url

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -22,15 +22,13 @@ load_previous_npm_node_versions() {
 
 download_node() {
   local platform=linux-x64
+  local url="https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-x64.tar.gz"
 
   if [ ! -f ${cached_node} ]; then
-    echo "Resolving node version $node_version..."
-    if ! read number url < <(curl --silent --get --retry 5 --retry-max-time 15 --data-urlencode "range=$node_version" "https://nodebin.herokai.com/v1/node/$platform/latest.txt"); then
-      fail_bin_install node $node_version;
-    fi
+    echo "Downloading and installing node $node_version..."
 
-    echo "Downloading and installing node $number..."
     local code=$(curl "$url" -L --silent --fail --retry 5 --retry-max-time 15 -o ${cached_node} --write-out "%{http_code}")
+
     if [ "$code" != "200" ]; then
       echo "Unable to download node: $code" && false
     fi


### PR DESCRIPTION
We update the node download URL because https://nodebin.herokai.com/v1/node/$platform/latest.txt is down